### PR TITLE
Export only AVIF and WebP images

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -58,7 +58,7 @@ module.exports = async function(eleventyConfig) {
 	eleventyConfig.addPlugin(IdAttributePlugin);
   // Using Eleventy Image Plugin
   eleventyConfig.addPlugin(eleventyImageTransformPlugin, {
-    formats: ['avif', 'webp', 'auto'],
+    formats: ['avif', 'webp'],
     widths: ['auto'],
     htmlOptions: {
       imgAttributes: {


### PR DESCRIPTION
Updated 11ty images setting to only export AVIF and WebP versions of images since all modern browsers are now using those two formats.