### PR TITLE
Add netlify-plugin-cache for improved build caching

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,12 @@
 [build.environment]
   NODE_VERSION = "20"
   ELEVENTY_RUN_MODE = "build"
+
+[[plugins]]
+  package = "netlify-plugin-cache"
+  
+  [plugins.inputs]
+    paths = [
+      ".cache",
+      "img"
+    ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "devDependencies": {
         "concurrently": "^9.2.1",
         "html-minifier-terser": "^7.2.0",
+        "netlify-plugin-cache": "^1.0.3",
         "sass": "^1.93.2",
         "terser": "^5.44.0"
       }
@@ -2428,6 +2429,13 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/netlify-plugin-cache": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/netlify-plugin-cache/-/netlify-plugin-cache-1.0.3.tgz",
+      "integrity": "sha512-CTOwNWrTOP59T6y6unxQNnp1WX702v2R/faR5peSH94ebrYfyY4zT5IsRcIiHKq57jXeyCrhy0GLuTN8ktzuQg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/no-case": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "concurrently": "^9.2.1",
     "html-minifier-terser": "^7.2.0",
+    "netlify-plugin-cache": "^1.0.3",
     "sass": "^1.93.2",
     "terser": "^5.44.0"
   }


### PR DESCRIPTION
Integrate the netlify-plugin-cache to enhance build performance by caching specified directories. Update configuration in netlify.toml accordingly.